### PR TITLE
Do not pass parameters with value None in payload

### DIFF
--- a/actions/run.py
+++ b/actions/run.py
@@ -23,6 +23,10 @@ class SlackAction(Action):
         headers = {}
         headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
+        for key in params.keys():
+            if params[key] is None:
+                del params[key]
+
         data = urllib.urlencode(params)
         self.logger.info(data)
         response = requests.get(url=url,

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version : 0.5.0
+version : 0.6.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
If a parameter has a value = None, then it is no longer passed in the payload. Without this fix, it was impossible to post a message to a channel.