### PR TITLE
Remove required flag from 'action_token'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.6.2
+
+- Remove required flag from `action_token` since other sections could be configured without relying on it.
+
 # 0.4.0
 
 - Updated action `runner_type` from `run-python` to `python-script`

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -43,7 +43,7 @@
   action_token:
     description: "Slack Action token."
     type: "string"
-    required: true
+    required: false
     secret: true
   admin:
     description: "Admin-action specific settings."

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version : 0.6.1
+version : 0.6.2
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
For example, if we need to configure `admin` section only, `action_token` is not required.