### PR TITLE
Corrected the inconsistency of required type and default value at some parameters in the config schema file

### DIFF
--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -8,7 +8,6 @@
       webhook_url:
         type: "string"
         description: "Webhook URL, e.g. https://hooks.slack.com/services/<replace me>"
-        default: true
         required: true
       channel:
         type: "string"
@@ -32,7 +31,7 @@
       token:
         type: "string"
         description: "Authentication token used to authenticate against Real Time Messaging API."
-        default: true
+        default: ""
         required: false
         secret: true
       strip_formatting:
@@ -54,7 +53,7 @@
       admin_token:
         type: "string"
         description: "Admin-level token for adding new users"
-        default: true
+        default: ""
         required: false
         secret: true
       organization:


### PR DESCRIPTION
When I configured this pack by the `st2 pack config` command and skip to set some parameter, a validation error may be occurred because of the inconsistent typed value.

This patch corrects the inconsistency of required type and default value at some parameters ('webhook_url', 'token' and 'admin_token') in the config schema to fix it.

Thank you.