### PR TITLE
Fix `include_labels` parameter type for `users.profile.get` action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.6.4
+
+- Fixed `include_labels` parameter type for `users.profile.get` action.
+
 # 0.6.2
 
 - Remove required flag from `action_token` since other sections could be configured without relying on it.

--- a/actions/users.profile.get.yaml
+++ b/actions/users.profile.get.yaml
@@ -1,4 +1,4 @@
-description: Use this method to retrieve a user's profile information.
+description: "Use this method to retrieve a user's profile information."
 enabled: true
 entry_point: run.py
 name: users.profile.get
@@ -13,7 +13,7 @@ parameters:
   include_labels:
     required: false
     default: false
-    type: string
+    type: boolean
   user:
     required: false
     type: string

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 0.6.3
+version: 0.6.4
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
This PR fixes execution of `slack.users.profile.get` action in ST2.
The `include_labels` parameter has had `string` type, but assigned a default value of `boolean` (`false`).
That throws validation error.

Bumped version in `pack.yaml` and updated changelog entry as well.