### PR TITLE
Add `users_filter_by` custom action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.8.0
+
+- Added custom `users_filter_by` action.
+
 # 0.7.0
 
 - Enforce default values to be a string type in YAML action definitions.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The following two actions are provided by the Slack pack.
 
 * ``post_message`` - Post a message to the specified channel using an incoming webhook.
 * ``users.admin.invite`` - Send an invitation to join a Slack Org.
+* ``users_filter_by`` - List users in a Slack team matching certain creterias.
 
 All other actions are as documented on the [Slack API Methods](https://api.slack.com/methods) page.
 

--- a/actions/users_filter_by.py
+++ b/actions/users_filter_by.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+'''
+Lookup user by attibutes
+'''
+
+from fnmatch import fnmatch
+from run import SlackAction
+
+
+class FilterBy(SlackAction):  # pylint: disable=too-few-public-methods
+    '''
+    Main class
+    '''
+
+    def run(self, **kwargs):
+        '''
+        Return a list of users
+        '''
+
+        users = []
+        attrs = kwargs.pop('attributes')
+        res = super(FilterBy, self).run(**kwargs)
+
+        for user in res['members']:
+            match = True
+            for key, val in attrs.items():
+                if isinstance(val, basestring):
+                    if not fnmatch(user.get(key, ''), val):
+                        match = False
+                elif user.get(key) != val:
+                    match = False
+
+            if match:
+                users.append(user)
+
+        return users

--- a/actions/users_filter_by.yaml
+++ b/actions/users_filter_by.yaml
@@ -1,0 +1,21 @@
+description: "Lists users in a Slack team matching certain creterias."
+enabled: true
+entry_point: users_filter_by.py
+name: users_filter_by
+parameters:
+  end_point:
+    default: users.list
+    immutable: true
+    type: string
+  attributes:
+    required: false
+    type: object
+    description: >-
+      Dictionary of user attributes to match against.
+      It supports shell-style wildcards for the string values.
+      Example: '{"name": "joe", "real_name": "Joe*", "is_bot": false}'.
+    default: {}
+  token:
+    required: false
+    type: string
+runner_type: python-script

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 0.7.0
+version: 0.8.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
This PR adds new action: `slack.users_filter_by`. It is based on `users.list` action created from Slack API method, but allows to filter users by attributes present in user object. Basically it's very simple query to get a list of specific user(s). Globs (shell-style wildcards) for string values are supported as well.

This becomes particularly useful with `chatops` pack to get more targeted messages to users in Slack team. The action metadata YAML contains an example of how it could be leveraged.

@LindsayHill I hope this would be a good addition, please review my changes. Thank you!