### PR TITLE
Add secret: true for webhook_url in config.schema.yaml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.9.0
+
+- Add `secret: true` for `webhook_url` in config.schema.yaml.
+
 # 0.8.0
 
 - Added custom `users_filter_by` action.

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -9,6 +9,7 @@
         type: "string"
         description: "Webhook URL, e.g. https://hooks.slack.com/services/<replace me>"
         required: true
+        secret: true
       channel:
         type: "string"
         description: "Channel to send message to - e.g. #mychannel. If not specified, will use channel selected when configuring webook"

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 0.8.0
+version: 0.9.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
So we can use an encrypted value for webhook_url in the datastore.