### PR TITLE
Use HTTP POST for files.upload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.10.1
+
+* Fix to use POST in `files.upload` action so that it can upload larger content.
+
 # 0.10.0
 
 * Fortify `send_invite.py` to better handle optional parameters.

--- a/actions/run.py
+++ b/actions/run.py
@@ -6,6 +6,10 @@ from st2common.runners.base_action import Action
 
 BASE_URL = 'https://slack.com/api/'
 
+# End points listed below use POST instead of GET
+POST_END_POINTS = [
+    'files.upload'
+]
 
 class SlackAction(Action):
 
@@ -13,9 +17,9 @@ class SlackAction(Action):
         if kwargs.get('token', None) is None:
             kwargs['token'] = self.config['action_token']
 
-        return self._get_request(kwargs)
+        return self._do_request(kwargs)
 
-    def _get_request(self, params):
+    def _do_request(self, params):
         end_point = params['end_point']
         url = urlparse.urljoin(BASE_URL, end_point)
         del params['end_point']
@@ -29,8 +33,12 @@ class SlackAction(Action):
 
         data = urllib.urlencode(params)
 
-        response = requests.get(url=url,
-                                headers=headers, params=data)
+        if end_point in POST_END_POINTS:
+            response = requests.post(url=url,
+                                     headers=headers, data=data)
+        else:
+            response = requests.get(url=url,
+                                    headers=headers, params=data)
 
         results = response.json()
         if not results['ok']:

--- a/actions/run.py
+++ b/actions/run.py
@@ -11,6 +11,7 @@ POST_END_POINTS = [
     'files.upload'
 ]
 
+
 class SlackAction(Action):
 
     def run(self, **kwargs):

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 0.10.0
+version: 0.10.1
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Without this patch all API calls including `files.upload` uses GET method with all data attached to request header. This will easily hit the request size hard limit set by AWS CloudFront (described [here](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-limits.html#limits-general)), which is the LB of `slack.com/api`, and affects `files.upload` that it can only upload around ~20KB data even Slack itself allows upto 1MB.

This PR changes it to use POST instead for selected API endpoints to avoid that CloudFront hard limit. Currently only `files.upload` is included in the list.

Fixes #14 