### PR TITLE
Add thread_ts parameter to files.upload action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.10.2
+
+* Add thread_ts parameter to `files.upload` action.
+
 # 0.10.1
 
 * Fix to use POST in `files.upload` action so that it can upload larger content.

--- a/actions/files.upload.yaml
+++ b/actions/files.upload.yaml
@@ -28,6 +28,9 @@ parameters:
   initial_comment:
     required: false
     type: string
+  thread_ts:
+    required: false
+    type: string
   title:
     required: false
     type: string

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 0.10.1
+version: 0.10.2
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
This patch follows the Slack API changes rolled out on 2018-07-23

See:
- https://api.slack.com/methods/files.upload
- https://api.slack.com/changelog/2018-05-file-threads-soon-tread