### PR TITLE
Add all actions currently available at api.slack.com

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,43 @@
 # Change Log
 
+# 0.10.3
+
+- Sync with the latest Slack API.
+- Added:
+    - `apps.permissions.info`
+    - `apps.permissions.request`
+    - `apps.permissions.resources.list`
+    - `apps.permissions.scopes.list`
+    - `apps.permissions.users.list`
+    - `apps.permissions.users.request`
+    - `chat.getPermalink`
+    - `chat.postEphemeral`
+    - `conversations.archive`
+    - `conversations.close`
+    - `conversations.create`
+    - `conversations.history`
+    - `conversations.info`
+    - `conversations.invite`
+    - `conversations.join`
+    - `conversations.kick`
+    - `conversations.leave`
+    - `conversations.list`
+    - `conversations.members`
+    - `conversations.open`
+    - `conversations.rename`
+    - `conversations.replies`
+    - `conversations.setPurpose`
+    - `conversations.setTopic`
+    - `conversations.unarchive`
+    - `dialog.open`
+    - `migration.exchange`
+    - `oauth.token`
+    - `users.conversations`
+    - `users.lookupByEmail`
+- Modified:
+    - `oauth.access`
+        - Add `single_channel` optional parameter
+
 # 0.10.2
 
 * Add thread_ts parameter to `files.upload` action.

--- a/actions/apps.permissions.info.yaml
+++ b/actions/apps.permissions.info.yaml
@@ -1,0 +1,13 @@
+description: "Returns list of permissions this app has on a team."
+enabled: true
+entry_point: run.py
+name: apps.permissions.info
+parameters:
+  end_point:
+    default: apps.permissions.info
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+runner_type: python-script

--- a/actions/apps.permissions.request.yaml
+++ b/actions/apps.permissions.request.yaml
@@ -1,0 +1,19 @@
+description: "Allows an app to request additional scopes"
+enabled: true
+entry_point: run.py
+name: apps.permissions.request
+parameters:
+  end_point:
+    default: apps.permissions.request
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  scopes:
+    required: true
+    type: string
+  trigger_id:
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/apps.permissions.resources.list.yaml
+++ b/actions/apps.permissions.resources.list.yaml
@@ -1,0 +1,19 @@
+description: "Returns list of resource grants this app has on a team."
+enabled: true
+entry_point: run.py
+name: apps.permissions.resources.list
+parameters:
+  end_point:
+    default: apps.permissions.resources.list
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  cursor:
+    required: false
+    type: string
+  limit:
+    required: false
+    type: string
+runner_type: python-script

--- a/actions/apps.permissions.scopes.list.yaml
+++ b/actions/apps.permissions.scopes.list.yaml
@@ -1,0 +1,13 @@
+description: "Returns list of scopes this app has on a team."
+enabled: true
+entry_point: run.py
+name: apps.permissions.scopes.list
+parameters:
+  end_point:
+    default: apps.permissions.scopes.list
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+runner_type: python-script

--- a/actions/apps.permissions.users.list.yaml
+++ b/actions/apps.permissions.users.list.yaml
@@ -1,0 +1,19 @@
+description: "Returns list of user grants and corresponding scopes this app has on a team."
+enabled: true
+entry_point: run.py
+name: apps.permissions.users.list
+parameters:
+  end_point:
+    default: apps.permissions.users.list
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  cursor:
+    required: false
+    type: string
+  limit:
+    required: false
+    type: string
+runner_type: python-script

--- a/actions/apps.permissions.users.request.yaml
+++ b/actions/apps.permissions.users.request.yaml
@@ -1,0 +1,22 @@
+description: "Enables an app to trigger a permissions modal to grant an app access to a user access scope."
+enabled: true
+entry_point: run.py
+name: apps.permissions.users.request
+parameters:
+  end_point:
+    default: apps.permissions.users.request
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  scopes:
+    required: true
+    type: string
+  trigger_id:
+    required: true
+    type: string
+  user:
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/chat.getPermalink.yaml
+++ b/actions/chat.getPermalink.yaml
@@ -1,0 +1,19 @@
+description: "Retrieve a permalink URL for a specific extant message"
+enabled: true
+entry_point: run.py
+name: chat.getPermalink
+parameters:
+  end_point:
+    default: chat.getPermalink
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+  message_ts:
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/chat.postEphemeral.yaml
+++ b/actions/chat.postEphemeral.yaml
@@ -1,0 +1,34 @@
+description: "Sends an ephemeral message to a user in a channel."
+enabled: true
+entry_point: run.py
+name: chat.postEphemeral
+parameters:
+  end_point:
+    default: chat.postEphemeral
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+  text:
+    required: true
+    type: string
+  user:
+    required: true
+    type: string
+  as_user:
+    required: false
+    type: string
+  attachments:
+    required: false
+    type: string
+  link_names:
+    required: false
+    type: string
+  parse:
+    required: false
+    type: string
+runner_type: python-script

--- a/actions/conversations.archive.yaml
+++ b/actions/conversations.archive.yaml
@@ -1,0 +1,16 @@
+description: "Archives a conversation."
+enabled: true
+entry_point: run.py
+name: conversations.archive
+parameters:
+  end_point:
+    default: conversations.archive
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/conversations.close.yaml
+++ b/actions/conversations.close.yaml
@@ -1,0 +1,16 @@
+description: "Closes a direct message or multi-person direct message."
+enabled: true
+entry_point: run.py
+name: conversations.close
+parameters:
+  end_point:
+    default: conversations.close
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/conversations.create.yaml
+++ b/actions/conversations.create.yaml
@@ -1,0 +1,22 @@
+description: "Initiates a public or private channel-based conversation"
+enabled: true
+entry_point: run.py
+name: conversations.create
+parameters:
+  end_point:
+    default: conversations.create
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  name:
+    required: true
+    type: string
+  is_private:
+    required: false
+    type: string
+  user_ids:
+    required: false
+    type: string
+runner_type: python-script

--- a/actions/conversations.history.yaml
+++ b/actions/conversations.history.yaml
@@ -1,0 +1,35 @@
+description: "Fetches a conversation's history of messages and events."
+enabled: true
+entry_point: run.py
+name: conversations.history
+parameters:
+  end_point:
+    default: conversations.history
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+  cursor:
+    required: false
+    type: string
+  inclusive:
+    required: false
+    default: "0"
+    type: string
+  latest:
+    required: false
+    default: "now"
+    type: string
+  limit:
+    required: false
+    default: "100"
+    type: string
+  oldest:
+    required: false
+    default: "0"
+    type: string
+runner_type: python-script

--- a/actions/conversations.info.yaml
+++ b/actions/conversations.info.yaml
@@ -1,0 +1,19 @@
+description: "Retrieve information about a conversation."
+enabled: true
+entry_point: run.py
+name: conversations.info
+parameters:
+  end_point:
+    default: conversations.info
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+  include_locale:
+    required: false
+    type: string
+runner_type: python-script

--- a/actions/conversations.invite.yaml
+++ b/actions/conversations.invite.yaml
@@ -1,0 +1,19 @@
+description: "Invites users to a channel."
+enabled: true
+entry_point: run.py
+name: conversations.invite
+parameters:
+  end_point:
+    default: conversations.invite
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+  users:
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/conversations.join.yaml
+++ b/actions/conversations.join.yaml
@@ -1,0 +1,16 @@
+description: "Joins an existing conversation."
+enabled: true
+entry_point: run.py
+name: conversations.join
+parameters:
+  end_point:
+    default: conversations.join
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/conversations.kick.yaml
+++ b/actions/conversations.kick.yaml
@@ -1,0 +1,19 @@
+description: "Removes a user from a conversation."
+enabled: true
+entry_point: run.py
+name: conversations.kick
+parameters:
+  end_point:
+    default: conversations.kick
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+  user:
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/conversations.leave.yaml
+++ b/actions/conversations.leave.yaml
@@ -1,0 +1,16 @@
+description: "Leaves a conversation."
+enabled: true
+entry_point: run.py
+name: conversations.leave
+parameters:
+  end_point:
+    default: conversations.leave
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/conversations.list.yaml
+++ b/actions/conversations.list.yaml
@@ -1,0 +1,28 @@
+description: "Lists all channels in a Slack team."
+enabled: true
+entry_point: run.py
+name: conversations.list
+parameters:
+  end_point:
+    default: conversations.list
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  cursor:
+    required: false
+    type: string
+  exclude_archived:
+    required: false
+    default: "false"
+    type: string
+  limit:
+    required: false
+    default: "100"
+    type: string
+  types:
+    required: false
+    default: "public_channel"
+    type: string
+runner_type: python-script

--- a/actions/conversations.members.yaml
+++ b/actions/conversations.members.yaml
@@ -1,0 +1,23 @@
+description: "Retrieve members of a conversation."
+enabled: true
+entry_point: run.py
+name: conversations.members
+parameters:
+  end_point:
+    default: conversations.members
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+  cursor:
+    required: false
+    type: string
+  limit:
+    required: false
+    default: "100"
+    type: string
+runner_type: python-script

--- a/actions/conversations.open.yaml
+++ b/actions/conversations.open.yaml
@@ -1,0 +1,22 @@
+description: "Opens or resumes a direct message or multi-person direct message."
+enabled: true
+entry_point: run.py
+name: conversations.open
+parameters:
+  end_point:
+    default: conversations.open
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: false
+    type: string
+  return_im:
+    required: false
+    type: string
+  users:
+    required: false
+    type: string
+runner_type: python-script

--- a/actions/conversations.rename.yaml
+++ b/actions/conversations.rename.yaml
@@ -1,0 +1,19 @@
+description: "Renames a conversation."
+enabled: true
+entry_point: run.py
+name: conversations.rename
+parameters:
+  end_point:
+    default: conversations.rename
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+  name:
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/conversations.replies.yaml
+++ b/actions/conversations.replies.yaml
@@ -1,0 +1,38 @@
+description: "Retrieve a thread of messages posted to a conversation"
+enabled: true
+entry_point: run.py
+name: conversations.replies
+parameters:
+  end_point:
+    default: conversations.replies
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+  ts:
+    required: true
+    type: string
+  cursor:
+    required: false
+    type: string
+  inclusive:
+    required: false
+    default: "0"
+    type: string
+  latest:
+    required: false
+    default: "now"
+    type: string
+  limit:
+    required: false
+    default: "10"
+    type: string
+  oldest:
+    required: false
+    default: "0"
+    type: string
+runner_type: python-script

--- a/actions/conversations.setPurpose.yaml
+++ b/actions/conversations.setPurpose.yaml
@@ -1,0 +1,19 @@
+description: "Sets the purpose for a conversation."
+enabled: true
+entry_point: run.py
+name: conversations.setPurpose
+parameters:
+  end_point:
+    default: conversations.setPurpose
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+  purpose:
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/conversations.setTopic.yaml
+++ b/actions/conversations.setTopic.yaml
@@ -1,0 +1,19 @@
+description: "Sets the topic for a conversation."
+enabled: true
+entry_point: run.py
+name: conversations.setTopic
+parameters:
+  end_point:
+    default: conversations.setTopic
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+  topic:
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/conversations.unarchive.yaml
+++ b/actions/conversations.unarchive.yaml
@@ -1,0 +1,16 @@
+description: "Reverses conversation archival."
+enabled: true
+entry_point: run.py
+name: conversations.unarchive
+parameters:
+  end_point:
+    default: conversations.unarchive
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  channel:
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/dialog.open.yaml
+++ b/actions/dialog.open.yaml
@@ -1,0 +1,19 @@
+description: "Open a dialog with a user"
+enabled: true
+entry_point: run.py
+name: dialog.open
+parameters:
+  end_point:
+    default: dialog.open
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  dialog:
+    required: true
+    type: string
+  trigger_id:
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/migration.exchange.yaml
+++ b/actions/migration.exchange.yaml
@@ -1,0 +1,20 @@
+description: "For Enterprise Grid workspaces, map local user IDs to global user IDs"
+enabled: true
+entry_point: run.py
+name: migration.exchange
+parameters:
+  end_point:
+    default: migration.exchange
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  users:
+    required: true
+    type: string
+  to_old:
+    required: false
+    default: ""
+    type: string
+runner_type: python-script

--- a/actions/oauth.token.yaml
+++ b/actions/oauth.token.yaml
@@ -1,10 +1,10 @@
-description: "Exchanges a temporary OAuth verifier code for an access token."
+description: "Exchanges a temporary OAuth verifier code for a workspace token."
 enabled: true
 entry_point: run.py
-name: oauth.access
+name: oauth.token
 parameters:
   end_point:
-    default: oauth.access
+    default: oauth.token
     immutable: true
     type: string
   client_id:

--- a/actions/users.conversations.yaml
+++ b/actions/users.conversations.yaml
@@ -1,0 +1,31 @@
+description: "List conversations the calling user may access."
+enabled: true
+entry_point: run.py
+name: users.conversations
+parameters:
+  end_point:
+    default: users.conversations
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  cursor:
+    required: false
+    type: string
+  exclude_archived:
+    required: false
+    default: "false"
+    type: string
+  limit:
+    required: false
+    default: "100"
+    type: string
+  types:
+    required: false
+    default: "public_channel"
+    type: string
+  user:
+    required: false
+    type: string
+runner_type: python-script

--- a/actions/users.lookupByEmail.yaml
+++ b/actions/users.lookupByEmail.yaml
@@ -1,0 +1,16 @@
+description: "Find a user with an email address."
+enabled: true
+entry_point: run.py
+name: users.lookupByEmail
+parameters:
+  end_point:
+    default: users.lookupByEmail
+    immutable: true
+    type: string
+  token:
+    required: false
+    type: string
+  email:
+    required: true
+    type: string
+runner_type: python-script

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 0.10.2
+version: 0.10.3
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
This just adds all action metadata generated by the latest `slack_api_gen.py` from #27

Although some actions should be deleted since they are deprecated or totally deleted from Slack API, this keeps all existing actions to maximize backward compatibility. That will be handled in separate issue or PR.

The only modification made to existing actions in this PR is just the slight change of description and one optional parameter addition, so I decided to increment only patch version.