### PR TITLE
Use preferred HTTP method for all actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.11.0
+
+- All actions now uses preferred HTTP method mentioned in official API reference.
+
 # 0.10.4
 
 - Sync with the latest Slack API.

--- a/actions/api.test.yaml
+++ b/actions/api.test.yaml
@@ -7,6 +7,10 @@ parameters:
     default: api.test
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   error:
     required: false
     type: string

--- a/actions/apps.permissions.info.yaml
+++ b/actions/apps.permissions.info.yaml
@@ -7,6 +7,10 @@ parameters:
     default: apps.permissions.info
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/apps.permissions.request.yaml
+++ b/actions/apps.permissions.request.yaml
@@ -7,6 +7,10 @@ parameters:
     default: apps.permissions.request
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/apps.permissions.resources.list.yaml
+++ b/actions/apps.permissions.resources.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: apps.permissions.resources.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/apps.permissions.scopes.list.yaml
+++ b/actions/apps.permissions.scopes.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: apps.permissions.scopes.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/apps.permissions.users.list.yaml
+++ b/actions/apps.permissions.users.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: apps.permissions.users.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/apps.permissions.users.request.yaml
+++ b/actions/apps.permissions.users.request.yaml
@@ -7,6 +7,10 @@ parameters:
     default: apps.permissions.users.request
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/auth.revoke.yaml
+++ b/actions/auth.revoke.yaml
@@ -7,6 +7,10 @@ parameters:
     default: auth.revoke
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/auth.test.yaml
+++ b/actions/auth.test.yaml
@@ -7,6 +7,10 @@ parameters:
     default: auth.test
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/bots.info.yaml
+++ b/actions/bots.info.yaml
@@ -7,6 +7,10 @@ parameters:
     default: bots.info
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.archive.yaml
+++ b/actions/channels.archive.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.archive
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.create.yaml
+++ b/actions/channels.create.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.create
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.history.yaml
+++ b/actions/channels.history.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.history
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.info.yaml
+++ b/actions/channels.info.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.info
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.invite.yaml
+++ b/actions/channels.invite.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.invite
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.join.yaml
+++ b/actions/channels.join.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.join
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.kick.yaml
+++ b/actions/channels.kick.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.kick
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.leave.yaml
+++ b/actions/channels.leave.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.leave
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.list.yaml
+++ b/actions/channels.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.mark.yaml
+++ b/actions/channels.mark.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.mark
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.rename.yaml
+++ b/actions/channels.rename.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.rename
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.replies.yaml
+++ b/actions/channels.replies.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.replies
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.setPurpose.yaml
+++ b/actions/channels.setPurpose.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.setPurpose
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.setTopic.yaml
+++ b/actions/channels.setTopic.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.setTopic
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/channels.unarchive.yaml
+++ b/actions/channels.unarchive.yaml
@@ -7,6 +7,10 @@ parameters:
     default: channels.unarchive
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/chat.delete.yaml
+++ b/actions/chat.delete.yaml
@@ -7,6 +7,10 @@ parameters:
     default: chat.delete
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/chat.getPermalink.yaml
+++ b/actions/chat.getPermalink.yaml
@@ -7,6 +7,10 @@ parameters:
     default: chat.getPermalink
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/chat.meMessage.yaml
+++ b/actions/chat.meMessage.yaml
@@ -7,6 +7,10 @@ parameters:
     default: chat.meMessage
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/chat.postEphemeral.yaml
+++ b/actions/chat.postEphemeral.yaml
@@ -7,6 +7,10 @@ parameters:
     default: chat.postEphemeral
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/chat.postMessage.yaml
+++ b/actions/chat.postMessage.yaml
@@ -7,6 +7,10 @@ parameters:
     default: chat.postMessage
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/chat.unfurl.yaml
+++ b/actions/chat.unfurl.yaml
@@ -7,6 +7,10 @@ parameters:
     default: chat.unfurl
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/chat.update.yaml
+++ b/actions/chat.update.yaml
@@ -7,6 +7,10 @@ parameters:
     default: chat.update
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.archive.yaml
+++ b/actions/conversations.archive.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.archive
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.close.yaml
+++ b/actions/conversations.close.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.close
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.create.yaml
+++ b/actions/conversations.create.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.create
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.history.yaml
+++ b/actions/conversations.history.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.history
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.info.yaml
+++ b/actions/conversations.info.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.info
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.invite.yaml
+++ b/actions/conversations.invite.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.invite
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.join.yaml
+++ b/actions/conversations.join.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.join
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.kick.yaml
+++ b/actions/conversations.kick.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.kick
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.leave.yaml
+++ b/actions/conversations.leave.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.leave
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.list.yaml
+++ b/actions/conversations.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.members.yaml
+++ b/actions/conversations.members.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.members
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.open.yaml
+++ b/actions/conversations.open.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.open
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.rename.yaml
+++ b/actions/conversations.rename.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.rename
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.replies.yaml
+++ b/actions/conversations.replies.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.replies
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.setPurpose.yaml
+++ b/actions/conversations.setPurpose.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.setPurpose
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.setTopic.yaml
+++ b/actions/conversations.setTopic.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.setTopic
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/conversations.unarchive.yaml
+++ b/actions/conversations.unarchive.yaml
@@ -7,6 +7,10 @@ parameters:
     default: conversations.unarchive
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/dialog.open.yaml
+++ b/actions/dialog.open.yaml
@@ -7,6 +7,10 @@ parameters:
     default: dialog.open
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/dnd.endDnd.yaml
+++ b/actions/dnd.endDnd.yaml
@@ -7,6 +7,10 @@ parameters:
     default: dnd.endDnd
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/dnd.endSnooze.yaml
+++ b/actions/dnd.endSnooze.yaml
@@ -7,6 +7,10 @@ parameters:
     default: dnd.endSnooze
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/dnd.info.yaml
+++ b/actions/dnd.info.yaml
@@ -7,6 +7,10 @@ parameters:
     default: dnd.info
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/dnd.setSnooze.yaml
+++ b/actions/dnd.setSnooze.yaml
@@ -7,6 +7,10 @@ parameters:
     default: dnd.setSnooze
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/dnd.teamInfo.yaml
+++ b/actions/dnd.teamInfo.yaml
@@ -7,6 +7,10 @@ parameters:
     default: dnd.teamInfo
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/emoji.list.yaml
+++ b/actions/emoji.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: emoji.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/files.comments.add.yaml
+++ b/actions/files.comments.add.yaml
@@ -7,6 +7,10 @@ parameters:
     default: files.comments.add
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/files.comments.delete.yaml
+++ b/actions/files.comments.delete.yaml
@@ -7,6 +7,10 @@ parameters:
     default: files.comments.delete
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/files.comments.edit.yaml
+++ b/actions/files.comments.edit.yaml
@@ -7,6 +7,10 @@ parameters:
     default: files.comments.edit
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/files.delete.yaml
+++ b/actions/files.delete.yaml
@@ -7,6 +7,10 @@ parameters:
     default: files.delete
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/files.info.yaml
+++ b/actions/files.info.yaml
@@ -7,6 +7,10 @@ parameters:
     default: files.info
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/files.list.yaml
+++ b/actions/files.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: files.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/files.revokePublicURL.yaml
+++ b/actions/files.revokePublicURL.yaml
@@ -7,6 +7,10 @@ parameters:
     default: files.revokePublicURL
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/files.sharedPublicURL.yaml
+++ b/actions/files.sharedPublicURL.yaml
@@ -7,6 +7,10 @@ parameters:
     default: files.sharedPublicURL
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/files.upload.yaml
+++ b/actions/files.upload.yaml
@@ -7,6 +7,10 @@ parameters:
     default: files.upload
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.archive.yaml
+++ b/actions/groups.archive.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.archive
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.create.yaml
+++ b/actions/groups.create.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.create
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.createChild.yaml
+++ b/actions/groups.createChild.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.createChild
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.history.yaml
+++ b/actions/groups.history.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.history
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.info.yaml
+++ b/actions/groups.info.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.info
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.invite.yaml
+++ b/actions/groups.invite.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.invite
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.kick.yaml
+++ b/actions/groups.kick.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.kick
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.leave.yaml
+++ b/actions/groups.leave.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.leave
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.list.yaml
+++ b/actions/groups.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.mark.yaml
+++ b/actions/groups.mark.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.mark
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.open.yaml
+++ b/actions/groups.open.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.open
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.rename.yaml
+++ b/actions/groups.rename.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.rename
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.replies.yaml
+++ b/actions/groups.replies.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.replies
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.setPurpose.yaml
+++ b/actions/groups.setPurpose.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.setPurpose
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.setTopic.yaml
+++ b/actions/groups.setTopic.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.setTopic
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/groups.unarchive.yaml
+++ b/actions/groups.unarchive.yaml
@@ -7,6 +7,10 @@ parameters:
     default: groups.unarchive
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/im.close.yaml
+++ b/actions/im.close.yaml
@@ -7,6 +7,10 @@ parameters:
     default: im.close
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/im.history.yaml
+++ b/actions/im.history.yaml
@@ -7,6 +7,10 @@ parameters:
     default: im.history
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/im.list.yaml
+++ b/actions/im.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: im.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/im.mark.yaml
+++ b/actions/im.mark.yaml
@@ -7,6 +7,10 @@ parameters:
     default: im.mark
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/im.open.yaml
+++ b/actions/im.open.yaml
@@ -7,6 +7,10 @@ parameters:
     default: im.open
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/im.replies.yaml
+++ b/actions/im.replies.yaml
@@ -7,6 +7,10 @@ parameters:
     default: im.replies
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/migration.exchange.yaml
+++ b/actions/migration.exchange.yaml
@@ -7,6 +7,10 @@ parameters:
     default: migration.exchange
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/mpim.close.yaml
+++ b/actions/mpim.close.yaml
@@ -7,6 +7,10 @@ parameters:
     default: mpim.close
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/mpim.history.yaml
+++ b/actions/mpim.history.yaml
@@ -7,6 +7,10 @@ parameters:
     default: mpim.history
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/mpim.list.yaml
+++ b/actions/mpim.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: mpim.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/mpim.mark.yaml
+++ b/actions/mpim.mark.yaml
@@ -7,6 +7,10 @@ parameters:
     default: mpim.mark
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/mpim.open.yaml
+++ b/actions/mpim.open.yaml
@@ -7,6 +7,10 @@ parameters:
     default: mpim.open
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/mpim.replies.yaml
+++ b/actions/mpim.replies.yaml
@@ -7,6 +7,10 @@ parameters:
     default: mpim.replies
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/oauth.access.yaml
+++ b/actions/oauth.access.yaml
@@ -7,6 +7,10 @@ parameters:
     default: oauth.access
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   client_id:
     required: true
     type: string

--- a/actions/oauth.token.yaml
+++ b/actions/oauth.token.yaml
@@ -7,6 +7,10 @@ parameters:
     default: oauth.token
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   client_id:
     required: true
     type: string

--- a/actions/pins.add.yaml
+++ b/actions/pins.add.yaml
@@ -7,6 +7,10 @@ parameters:
     default: pins.add
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/pins.list.yaml
+++ b/actions/pins.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: pins.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/pins.remove.yaml
+++ b/actions/pins.remove.yaml
@@ -7,6 +7,10 @@ parameters:
     default: pins.remove
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/reactions.add.yaml
+++ b/actions/reactions.add.yaml
@@ -7,6 +7,10 @@ parameters:
     default: reactions.add
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/reactions.get.yaml
+++ b/actions/reactions.get.yaml
@@ -7,6 +7,10 @@ parameters:
     default: reactions.get
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/reactions.list.yaml
+++ b/actions/reactions.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: reactions.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/reactions.remove.yaml
+++ b/actions/reactions.remove.yaml
@@ -7,6 +7,10 @@ parameters:
     default: reactions.remove
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/reminders.add.yaml
+++ b/actions/reminders.add.yaml
@@ -7,6 +7,10 @@ parameters:
     default: reminders.add
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/reminders.complete.yaml
+++ b/actions/reminders.complete.yaml
@@ -7,6 +7,10 @@ parameters:
     default: reminders.complete
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/reminders.delete.yaml
+++ b/actions/reminders.delete.yaml
@@ -7,6 +7,10 @@ parameters:
     default: reminders.delete
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/reminders.info.yaml
+++ b/actions/reminders.info.yaml
@@ -7,6 +7,10 @@ parameters:
     default: reminders.info
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/reminders.list.yaml
+++ b/actions/reminders.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: reminders.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/rtm.connect.yaml
+++ b/actions/rtm.connect.yaml
@@ -7,6 +7,10 @@ parameters:
     default: rtm.connect
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/rtm.start.yaml
+++ b/actions/rtm.start.yaml
@@ -7,6 +7,10 @@ parameters:
     default: rtm.start
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/search.all.yaml
+++ b/actions/search.all.yaml
@@ -7,6 +7,10 @@ parameters:
     default: search.all
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/search.files.yaml
+++ b/actions/search.files.yaml
@@ -7,6 +7,10 @@ parameters:
     default: search.files
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/search.messages.yaml
+++ b/actions/search.messages.yaml
@@ -7,6 +7,10 @@ parameters:
     default: search.messages
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/stars.add.yaml
+++ b/actions/stars.add.yaml
@@ -7,6 +7,10 @@ parameters:
     default: stars.add
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/stars.list.yaml
+++ b/actions/stars.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: stars.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/stars.remove.yaml
+++ b/actions/stars.remove.yaml
@@ -7,6 +7,10 @@ parameters:
     default: stars.remove
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/team.accessLogs.yaml
+++ b/actions/team.accessLogs.yaml
@@ -7,6 +7,10 @@ parameters:
     default: team.accessLogs
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/team.billableInfo.yaml
+++ b/actions/team.billableInfo.yaml
@@ -7,6 +7,10 @@ parameters:
     default: team.billableInfo
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/team.info.yaml
+++ b/actions/team.info.yaml
@@ -7,6 +7,10 @@ parameters:
     default: team.info
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/team.integrationLogs.yaml
+++ b/actions/team.integrationLogs.yaml
@@ -7,6 +7,10 @@ parameters:
     default: team.integrationLogs
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/team.profile.get.yaml
+++ b/actions/team.profile.get.yaml
@@ -7,6 +7,10 @@ parameters:
     default: team.profile.get
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/usergroups.create.yaml
+++ b/actions/usergroups.create.yaml
@@ -7,6 +7,10 @@ parameters:
     default: usergroups.create
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/usergroups.disable.yaml
+++ b/actions/usergroups.disable.yaml
@@ -7,6 +7,10 @@ parameters:
     default: usergroups.disable
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/usergroups.enable.yaml
+++ b/actions/usergroups.enable.yaml
@@ -7,6 +7,10 @@ parameters:
     default: usergroups.enable
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/usergroups.list.yaml
+++ b/actions/usergroups.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: usergroups.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/usergroups.update.yaml
+++ b/actions/usergroups.update.yaml
@@ -7,6 +7,10 @@ parameters:
     default: usergroups.update
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/usergroups.users.list.yaml
+++ b/actions/usergroups.users.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: usergroups.users.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/usergroups.users.update.yaml
+++ b/actions/usergroups.users.update.yaml
@@ -7,6 +7,10 @@ parameters:
     default: usergroups.users.update
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/users.conversations.yaml
+++ b/actions/users.conversations.yaml
@@ -7,6 +7,10 @@ parameters:
     default: users.conversations
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/users.deletePhoto.yaml
+++ b/actions/users.deletePhoto.yaml
@@ -7,6 +7,10 @@ parameters:
     default: users.deletePhoto
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/users.getPresence.yaml
+++ b/actions/users.getPresence.yaml
@@ -7,6 +7,10 @@ parameters:
     default: users.getPresence
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/users.identity.yaml
+++ b/actions/users.identity.yaml
@@ -7,6 +7,10 @@ parameters:
     default: users.identity
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/users.info.yaml
+++ b/actions/users.info.yaml
@@ -7,6 +7,10 @@ parameters:
     default: users.info
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/users.list.yaml
+++ b/actions/users.list.yaml
@@ -7,6 +7,10 @@ parameters:
     default: users.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/users.lookupByEmail.yaml
+++ b/actions/users.lookupByEmail.yaml
@@ -7,6 +7,10 @@ parameters:
     default: users.lookupByEmail
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/users.profile.get.yaml
+++ b/actions/users.profile.get.yaml
@@ -7,6 +7,10 @@ parameters:
     default: users.profile.get
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/users.profile.set.yaml
+++ b/actions/users.profile.set.yaml
@@ -7,6 +7,10 @@ parameters:
     default: users.profile.set
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/users.setActive.yaml
+++ b/actions/users.setActive.yaml
@@ -7,6 +7,10 @@ parameters:
     default: users.setActive
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/users.setPhoto.yaml
+++ b/actions/users.setPhoto.yaml
@@ -7,6 +7,10 @@ parameters:
     default: users.setPhoto
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/users.setPresence.yaml
+++ b/actions/users.setPresence.yaml
@@ -7,6 +7,10 @@ parameters:
     default: users.setPresence
     immutable: true
     type: string
+  http_method:
+    default: POST
+    required: true
+    type: string
   token:
     required: false
     type: string

--- a/actions/users_filter_by.yaml
+++ b/actions/users_filter_by.yaml
@@ -7,6 +7,10 @@ parameters:
     default: users.list
     immutable: true
     type: string
+  http_method:
+    default: GET
+    required: true
+    type: string
   attributes:
     required: false
     type: object

--- a/etc/st2packgen/slack_api_gen.py
+++ b/etc/st2packgen/slack_api_gen.py
@@ -70,6 +70,16 @@ for method in api_methods.stripped_strings:
             method_dict[method]['params'][arg.text]['required'] = required
             method_dict[method]['params'][arg.text]['default'] = default
 
+        # parse Preferred HTTP method
+        method_facts_table = method_soup.find(
+            'h2',
+            attrs={"id": "facts"}).findNext('table')
+        preferred_method = method_facts_table.find(
+            'th',
+            text='Preferred HTTP method:').findNext('td').text
+        preferred_method = preferred_method.rstrip()
+        method_dict[method]['http_method'] = preferred_method
+
 for method in method_dict:
 
     actions_dir = os.path.normpath(os.path.join(
@@ -87,6 +97,10 @@ for method in method_dict:
         'type': 'string',
         'immutable': True,
         'default': method}
+    output_dict['parameters']['http_method'] = {
+        'type': 'string',
+        'default': method_dict[method]['http_method'],
+        'required': True}
 
     for param in method_dict[method]['params']:
         if param == 'token':

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 0.10.4
+version: 0.11.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
With this patch, all actions will use preferred HTTP method that are described in each Slack API doc.

Previously only `files.upload` action was using POST, and that was statically coded in `run.py` script. Now `slack_api_gen.py` parses API doc and extracts the preferred HTTP method for each API endpoint, and output that value as an input parameter in action metadata yamls. `run.py` takes that parameter, send request to Slack API endpoint using that method. It seems the choice is either GET or POST for now.

I make the parameter not immutable since the user still has a control to choose GET over POST for the actions that prefer POST, or vice versa.

This is *slightly* a backward incompatible change, so I'll going to give version `0.11.0`: All actions should just run in the exact same way without making any changes, but it is actually using the different HTTP method for some actions. I'm open to accept any comments on this.

Todo:
- [x] Update CHANGELOG.md