### PR TITLE
Fix to make `text` field optional in chat.postMessage action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.12.1
+
+- Fix `text` parameter to be optional in `chat.postMessage` action.
+
 # 0.12.0
 
 - Handling of cyrillic and special symbols in `run.py` through adding utf-8 encoding.

--- a/actions/chat.postMessage.yaml
+++ b/actions/chat.postMessage.yaml
@@ -18,7 +18,7 @@ parameters:
     required: true
     type: string
   text:
-    required: true
+    required: false
     type: string
   as_user:
     required: false

--- a/etc/st2packgen/slack_api_gen.py
+++ b/etc/st2packgen/slack_api_gen.py
@@ -114,6 +114,11 @@ for method in method_dict:
                     method_dict[method]['params'][param]['default'])
         output_dict['parameters'][param]['type'] = 'string'
 
+    # special care: text is not a mandatory parameter in chat.postMessage
+    # https://github.com/slackhq/slack-api-docs/issues/41
+    if method == 'chat.postMessage':
+        output_dict['parameters']['text']['required'] = False
+
     print yaml.safe_dump(
         output_dict, default_flow_style=False, width=float('inf'))
     fh = open(file_name, 'w')

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 0.12.0
+version: 0.12.1
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Because of the upstream bug in API document, generated action meta for `chat.postMessage` action is incorrect . Actually either `text` or `attachments` is required.

cf: https://github.com/slackhq/slack-api-docs/issues/41