### PR TITLE
pyyaml version bump for st2packgen

### DIFF
--- a/etc/st2packgen/requirements.txt
+++ b/etc/st2packgen/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML==3.13
+pyyaml==4.2b1
 argparse==1.2.1
 beautifulsoup4==4.6.0
 bs4==0.0.1


### PR DESCRIPTION
PyYAML has a security issue with < 4.2b1. Have bumped it here.

NB this is only used for generating new actions, it does not affect most users of this pack.