### PR TITLE
fix attachments parameter type in sensor.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.12.6
+
+- fix `attachments` parameter type in sensor.
+
 # 0.12.5
 
 - Bump allowed `requests()` version, remove httplib

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 0.12.5
+version: 0.12.6
 python_versions:
   - "2"
   - "3"

--- a/sensors/slack_sensor.yaml
+++ b/sensors/slack_sensor.yaml
@@ -21,4 +21,4 @@
           timestamp_raw:
             type: "string"
           attachments:
-            type: "object"
+            type: "array"


### PR DESCRIPTION
attachments should always be an array by slack docs: 
https://api.slack.com/docs/message-attachments
