### PR TITLE
Update dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# 0.12.7
+
+- fix `attachments` parameter type in sensor.
+- update `jinja` dependency to 2.10.1+
+- use upstream `slackclient` package
+
 # 0.12.6
 
 - Fix `text` parameter in `chat.update` to be `required: false`, same as `chat.postMessage`. `text` only required when `attachments` is `None` 

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 0.12.6
+version: 0.12.7
 python_versions:
   - "2"
   - "3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ websocket-client==0.44.0
 beautifulsoup4==4.6.0
 lxml==3.8.0
 jinja2>=2.10.1
--e git+https://github.com/Kami/python-slackclient.git@stackstorm_patched#egg=slackclient
+slackclient==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ requests>=2.5.0,<3.0
 websocket-client==0.44.0
 beautifulsoup4==4.6.0
 lxml==3.8.0
-jinja2==2.9.6
+jinja2>=2.10.1
 -e git+https://github.com/Kami/python-slackclient.git@stackstorm_patched#egg=slackclient

--- a/sensors/slack_sensor.yaml
+++ b/sensors/slack_sensor.yaml
@@ -21,4 +21,4 @@
           timestamp_raw:
             type: "string"
           attachments:
-            type: "object"
+            type: "array"


### PR DESCRIPTION
* Update Jinja dependency to `2.10.1` and greater - avoid [CVE-2019-10906](https://nvd.nist.gov/vuln/detail/CVE-2019-10906)
* Use upstream `slackclient` package instead of @Kami's fork, since all of his changes have either been reimplemented in upstream or are no longer necessary
* Merge #42, since it's [100% correct](https://api.slack.com/docs/message-attachments#attachment_structure):
  > Messages can have zero or more attachments, defined as an array.
* Bump pack version to `0.12.7`