### PR TITLE
Fixed 1 issue of type: PYTHON_E402 throughout 1 file in repo.

### DIFF
--- a/actions/run.py
+++ b/actions/run.py
@@ -1,3 +1,4 @@
+from st2common.runners.base_action import Action
 import requests
 import six
 
@@ -5,7 +6,6 @@ from six.moves.urllib.parse import urlencode
 from six.moves.urllib import parse as urlparse  # pylint: disable=import-error
 urljoin = urlparse.urljoin
 
-from st2common.runners.base_action import Action
 
 BASE_URL = 'https://slack.com/api/'
 


### PR DESCRIPTION
PYTHON_E402: 'module level import not at top of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.