### PR TITLE
Don't require config to be set when webhook_url is specified as part of action parameter

### DIFF
--- a/actions/post_message.py
+++ b/actions/post_message.py
@@ -13,11 +13,16 @@ __all__ = [
 class PostMessageAction(Action):
     def run(self, message, username=None, icon_emoji=None, channel=None,
             disable_formatting=False, webhook_url=None):
-        config = self.config['post_message_action']
+        config = self.config.get('post_message_action', {})
         username = username if username else config['username']
         icon_emoji = icon_emoji if icon_emoji else config.get('icon_emoji', None)
         channel = channel if channel else config.get('channel', None)
         webhook_url = webhook_url if webhook_url else config.get('webhook_url', None)
+
+        if not webhook_url:
+            raise ValueError('"webhook_url" needs to be either provided via '
+                             'action parameter or specified as part of '
+                             'post_message_action.webhook_url config option"')
 
         headers = {}
         headers['Content-Type'] = 'application/x-www-form-urlencoded'


### PR DESCRIPTION
This pull request fixes ``slack.post_message`` action so pack config is not required when ``webhook_url`` is provided as part of the action parameter.

This value can be provided either via config or via action parameter and if it's provided via action parameter, it doesn't need to be set in the config.