### PR TITLE
Various changes and improvements to the post_message action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Change Log
 
-# 0.12.9
+# 0.13.0
 
 - Various improvements to the ``slack.post_message`` action:
   - Make ``icon_emoji`` config option and parameter option. If it's not specified, it will now

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Change Log
 
+# 0.12.9
+
+- Various improvements to the ``slack.post_message`` action:
+  - Make ``icon_emoji`` config option and parameter option. If it's not specified, it will now
+    use server-side default.
+  - Add new ``icon_url`` parameter to the action.
+  - Make ``post_message_action.webhook_url`` config optional. This value can either be specified in
+   the config or overriden on per action invocation basis.
+
 # 0.12.8
 
 - Don't require ``post_message_action`` config option to be set when ``webhook_url`` parameter is

--- a/actions/post_message.py
+++ b/actions/post_message.py
@@ -11,11 +11,12 @@ __all__ = [
 
 
 class PostMessageAction(Action):
-    def run(self, message, username=None, icon_emoji=None, channel=None,
+    def run(self, message, username=None, icon_emoji=None, icon_url=None, channel=None,
             disable_formatting=False, webhook_url=None):
         config = self.config.get('post_message_action', {})
         username = username if username else config['username']
         icon_emoji = icon_emoji if icon_emoji else config.get('icon_emoji', None)
+        icon_url = icon_url if icon_url else config.get('icon_url', None)
         channel = channel if channel else config.get('channel', None)
         webhook_url = webhook_url if webhook_url else config.get('webhook_url', None)
 
@@ -28,9 +29,14 @@ class PostMessageAction(Action):
         headers['Content-Type'] = 'application/x-www-form-urlencoded'
         body = {
             'username': username,
-            'icon_emoji': icon_emoji,
             'text': message
         }
+
+        if icon_emoji:
+            body['icon_emoji'] = icon_emoji
+
+        if icon_url:
+            body['icon_url'] = icon_url
 
         if channel:
             body['channel'] = channel

--- a/actions/post_message.yaml
+++ b/actions/post_message.yaml
@@ -19,7 +19,11 @@
       required: false
     icon_emoji:
       type: "string"
-      description: "Bot icon"
+      description: "Bot icon emoji"
+      required: false
+    icon_url:
+      type: "string"
+      description: "Bot icon URL"
       required: false
     disable_formatting:
       type: "boolean"

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -8,7 +8,9 @@
       webhook_url:
         type: "string"
         description: "Webhook URL, e.g. https://hooks.slack.com/services/<replace me>"
-        required: true
+        # This value can be either specified via config or via action parameter
+        # so it should not be required
+        required: false
         secret: true
       channel:
         type: "string"
@@ -21,7 +23,6 @@
       icon_emoji:
         type: "string"
         description: "Default icon of user under which messages will be posted"
-        default: ":panda_face:"
         required: false
   sensor:
     description: "Sensor specific settings."

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 0.12.9
+version: 0.13.0
 python_versions:
   - "2"
   - "3"

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 0.12.8
+version: 0.12.9
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
This pull request includes a couple of improvements and fixes to the ``slack.post_message`` action.

* Make ``icon_emoji`` config option and parameter option. If it's not specified, it will now use server-side default. Previously it wasn't possible to do that and it always used default from the config.
* Add new ``icon_url`` parameter to the action.
* Make ``post_message_action.webhook_url`` config optional. This value can either be specified in
   the config or overridden on per action invocation basis. Previously this value needed to be specified even if it was overridden on per action invocation basis.