### PR TITLE
Support uploading files from the filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,29 @@ Notice how there are 15 parameters. The extra one is "end_point", which is used 
 to construct the end point URL.
 
 
-### Developer Reference
+### Uploading files with slack.files.upload
 
-#### How to auto-generate actions
+The action `slack.files.upload` is able to upload files to slack, such as pictures. 
+This action works a bit different than other actions in that the `file_path` parameter
+accepts a path to a file on the local filesystem. This path *must* be
+accessible from the the `st2actionrunner` executing the action.
+The `st2actionrunner` will open up the file path, read the contents and then upload
+this data to Slack as part of the action run.
+
+Example:
+
+```shell
+st2 run slack.files.upload file_path=/opt/data/mycoolimage.png filename=mycoolimage.png
+```
+
+If this is not desirabile and you would rather read the file or pass the data
+yourself, this can be accomplished using the `file` or `content` parameters which both
+accept raw data that will be uploaded.
+
+
+## Developer Reference
+
+### How to auto-generate actions
 
 If you're a pack developer working on this pack and want to auto-generate / update
 the actions here, please see [bin/README.md](bin/README.md)

--- a/actions/files.upload.yaml
+++ b/actions/files.upload.yaml
@@ -1,6 +1,6 @@
 description: "Uploads or creates a file."
 enabled: true
-entry_point: run.py
+entry_point: files_upload.py
 name: files.upload
 parameters:
   end_point:

--- a/actions/files.upload.yaml
+++ b/actions/files.upload.yaml
@@ -17,16 +17,16 @@ parameters:
     type: string
   content:
     required: false
-    description: "File contents via a POST variable. If omitting this parameter, you must provide a `file`."
+    description: "File contents via a POST variable. If omitting this parameter, you must provide either `file` or `content`."
     type: string
   file:
     required: false
-    description: "File contents via `multipart/form-data`. If omitting this parameter, you must submit `content`."
+    description: "File contents via `multipart/form-data`. If omitting this parameter, you must provide either `file` or `content`."
     type: string
   file_path:
     required: false
     default: ""
-    description: "Path to the file on the local filesystem that will be opened, read and uploaded to Slack. If omitting this parameter, you must submit either `file` or `content`."
+    description: "Path to the file on the local filesystem that will be opened, read and uploaded to Slack. If omitting this parameter, you must provide either `file` or `content`."
     type: string
   filename:
     required: false

--- a/actions/files.upload.yaml
+++ b/actions/files.upload.yaml
@@ -23,6 +23,11 @@ parameters:
     required: false
     description: "File contents via `multipart/form-data`. If omitting this parameter, you must submit `content`."
     type: string
+  file_path:
+    required: false
+    default: ""
+    description: "Path to the file on the local filesystem that will be opened, read and uploaded to Slack. If omitting this parameter, you must submit either `file` or `content`."
+    type: string
   filename:
     required: false
     description: "Filename of file."

--- a/actions/files.upload.yaml
+++ b/actions/files.upload.yaml
@@ -17,11 +17,11 @@ parameters:
     type: string
   content:
     required: false
-    description: "File contents via a POST variable. If omitting this parameter, you must provide either `file` or `content`."
+    description: "File contents via a POST variable. If omitting this parameter, you must provide either `file` or `file_path`."
     type: string
   file:
     required: false
-    description: "File contents via `multipart/form-data`. If omitting this parameter, you must provide either `file` or `content`."
+    description: "File contents via `multipart/form-data`. If omitting this parameter, you must provide either `file_path` or `content`."
     type: string
   file_path:
     required: false

--- a/actions/files_upload.py
+++ b/actions/files_upload.py
@@ -11,9 +11,9 @@ class FilesUploadAction(SlackAction):
                 raise RuntimeError('Passing in "file" and "file_path" at the same time is'
                                    ' not supported. If you would like to have this action'
                                    ' read the file from the filesystem and upload it for you'
-                                   ' then use the "file_path" paramter. Otherwise, if you'
+                                   ' then use the "file_path" parameter. Otherwise, if you'
                                    ' would like to read the file yourself and pass in the data'
-                                   ' then use the "file" paramter set to the content.')
+                                   ' then use the "file" parameter set to the content.')
             # the name 'file' is hard coded because that's the name of the parameter
             # that the Slack API is expecting
             files = {'file': open(kwargs['file_path'], 'rb')}

--- a/actions/files_upload.py
+++ b/actions/files_upload.py
@@ -4,13 +4,10 @@ from run import SlackAction
 class FilesUploadAction(SlackAction):
 
     def run(self, **kwargs):
-        if kwargs.get('token', None) is None:
-            kwargs['token'] = self.config['action_token']
-
         # https://requests.readthedocs.io/en/master/user/quickstart/#post-a-multipart-encoded-file
         files = None
         if 'file_path' in kwargs:
-            if 'file' in kwargs:
+            if 'file' in kwargs and kwargs['file']:
                 raise RuntimeError('Passing in "file" and "file_path" at the same time is'
                                    ' not supported. If you would like to have this action'
                                    ' read the file from the filesystem and upload it for you'
@@ -19,6 +16,8 @@ class FilesUploadAction(SlackAction):
                                    ' then use the "file" paramter set to the content.')
             # the name 'file' is hard coded because that's the name of the parameter
             # that the Slack API is expecting
-            files = {'file': open(kwargs['file'], 'rb')}
+            files = {'file': open(kwargs['file_path'], 'rb')}
+            kwargs.pop('file', None)
+            kwargs.pop('file_path')
 
         self._do_request(kwargs, files)

--- a/actions/files_upload.py
+++ b/actions/files_upload.py
@@ -20,4 +20,4 @@ class FilesUploadAction(SlackAction):
             kwargs.pop('file', None)
             kwargs.pop('file_path')
 
-        self._do_request(kwargs, files)
+        super(FilesUploadAction, self).run(files=files, **kwargs)

--- a/actions/files_upload.py
+++ b/actions/files_upload.py
@@ -1,5 +1,6 @@
 from run import SlackAction
 
+
 class FilesUploadAction(SlackAction):
 
     def run(self, **kwargs):
@@ -8,7 +9,14 @@ class FilesUploadAction(SlackAction):
 
         # https://requests.readthedocs.io/en/master/user/quickstart/#post-a-multipart-encoded-file
         files = None
-        if 'file' in kwargs['file']:
+        if 'file_path' in kwargs:
+            if 'file' in kwargs:
+                raise RuntimeError('Passing in "file" and "file_path" at the same time is'
+                                   ' not supported. If you would like to have this action'
+                                   ' read the file from the filesystem and upload it for you'
+                                   ' then use the "file_path" paramter. Otherwise, if you'
+                                   ' would like to read the file yourself and pass in the data'
+                                   ' then use the "file" paramter set to the content.')
             # the name 'file' is hard coded because that's the name of the parameter
             # that the Slack API is expecting
             files = {'file': open(kwargs['file'], 'rb')}

--- a/actions/files_upload.py
+++ b/actions/files_upload.py
@@ -1,0 +1,16 @@
+from run import SlackAction
+
+class FilesUploadAction(SlackAction):
+
+    def run(self, **kwargs):
+        if kwargs.get('token', None) is None:
+            kwargs['token'] = self.config['action_token']
+
+        # https://requests.readthedocs.io/en/master/user/quickstart/#post-a-multipart-encoded-file
+        files = None
+        if 'file' in kwargs['file']:
+            # the name 'file' is hard coded because that's the name of the parameter
+            # that the Slack API is expecting
+            files = {'file': open(kwargs['file'], 'rb')}
+
+        self._do_request(kwargs, files)

--- a/actions/run.py
+++ b/actions/run.py
@@ -62,15 +62,17 @@ class SlackAction(Action):
 
         if http_method == 'POST':
             if files:
-                # specifically do NOT Content-Type in headers here because the content type
+                # we do NOT want Content-Type set in headers here because the content type
                 # set above (application/x-www-form-urlencoded) will NOT work to
-                # upload files, instead we need requests to create a unique
+                # upload files. Instead we need requests to create a unique
                 # Content-Type: multipart/formdata; boundary-----XYZ123
-                # if we specify headers here with a Content-Type then file uploads
+                # This Content-Type and boundary string is unique will be generated
+                # automatically for us if we do no specify a Content-Type.
+                # If we specify headers here with a Content-Type then file uploads
                 # will not work and return mysterious errors
                 headers.pop('Content-Type', None)
 
-                # we're passing data as the params dict instead of
+                # We're passing data as the params dict instead of
                 # the URL encoded string 'data' from above, this is critical too
                 # so that all of the additional parameters will be included as
                 # multipart/formdata pieces. If you pass in the URL encoded data string

--- a/actions/run.py
+++ b/actions/run.py
@@ -12,10 +12,8 @@ BASE_URL = 'https://slack.com/api/'
 
 class SlackAction(Action):
 
-    def run(self, **kwargs):
-        return self._do_request(kwargs)
-
-    def _do_request(self, params, files=None):
+    def run(self, files=None, **kwargs):
+        params = kwargs
         if params.get('token', None) is None:
             params['token'] = self.config['action_token']
 
@@ -67,12 +65,12 @@ class SlackAction(Action):
                 # upload files. Instead we need requests to create a unique
                 # Content-Type: multipart/formdata; boundary-----XYZ123
                 # This Content-Type and boundary string is unique will be generated
-                # automatically for us if we do no specify a Content-Type.
+                # automatically for us if we do not specify a Content-Type.
                 # If we specify headers here with a Content-Type then file uploads
                 # will not work and return mysterious errors
                 headers.pop('Content-Type', None)
 
-                # We're passing data as the params dict instead of
+                # We're passing the params dict into the data parameter instead of
                 # the URL encoded string 'data' from above, this is critical too
                 # so that all of the additional parameters will be included as
                 # multipart/formdata pieces. If you pass in the URL encoded data string

--- a/actions/run.py
+++ b/actions/run.py
@@ -13,12 +13,12 @@ BASE_URL = 'https://slack.com/api/'
 class SlackAction(Action):
 
     def run(self, **kwargs):
-        if kwargs.get('token', None) is None:
-            kwargs['token'] = self.config['action_token']
-
         return self._do_request(kwargs)
 
     def _do_request(self, params, files=None):
+        if params.get('token', None) is None:
+            params['token'] = self.config['action_token']
+
         end_point = params['end_point']
         url = urljoin(BASE_URL, end_point)
         del params['end_point']
@@ -61,8 +61,27 @@ class SlackAction(Action):
         data = urlencode(encode_obj(params))
 
         if http_method == 'POST':
-            response = requests.post(url=url,
-                                     headers=headers, data=data, files=files)
+            if files:
+                # specifically do NOT Content-Type in headers here because the content type
+                # set above (application/x-www-form-urlencoded) will NOT work to
+                # upload files, instead we need requests to create a unique
+                # Content-Type: multipart/formdata; boundary-----XYZ123
+                # if we specify headers here with a Content-Type then file uploads
+                # will not work and return mysterious errors
+                headers.pop('Content-Type', None)
+
+                # we're passing data as the params dict instead of
+                # the URL encoded string 'data' from above, this is critical too
+                # so that all of the additional parameters will be included as
+                # multipart/formdata pieces. If you pass in the URL encoded data string
+                # from above, this will put that single string in one form part of
+                # the request and cause the request to fail. Instead what we want is
+                # requests to create one multipart/formdata content section for each
+                # parameters. By passing data=params (the dictionary) requests will
+                # do what we want
+                response = requests.post(url=url, headers=headers, data=params, files=files)
+            else:
+                response = requests.post(url=url, headers=headers, data=data)
         elif http_method == 'GET':
             response = requests.get(url=url,
                                     headers=headers, params=data)

--- a/actions/run.py
+++ b/actions/run.py
@@ -18,7 +18,7 @@ class SlackAction(Action):
 
         return self._do_request(kwargs)
 
-    def _do_request(self, params):
+    def _do_request(self, params, files=None):
         end_point = params['end_point']
         url = urljoin(BASE_URL, end_point)
         del params['end_point']
@@ -62,7 +62,7 @@ class SlackAction(Action):
 
         if http_method == 'POST':
             response = requests.post(url=url,
-                                     headers=headers, data=data)
+                                     headers=headers, data=data, files=files)
         elif http_method == 'GET':
             response = requests.get(url=url,
                                     headers=headers, params=data)

--- a/bin/generate_openapi.py
+++ b/bin/generate_openapi.py
@@ -20,11 +20,24 @@ METHOD_OVERRIDES = {
     'files.upload': {
         'entry_point': 'files_upload.py',
         'parameters': {
+            # overriding content and file to modify their descriptions
+            'content': {
+                'name': 'content',
+                'type': 'string',
+                'required': False,
+                'description': 'File contents via a POST variable. If omitting this parameter, you must provide either `file` or `content`.',  # noqa: E501
+            },
+            'file': {
+                'name': 'file',
+                'type': 'string',
+                'required': False,
+                'description': 'File contents via `multipart/form-data`. If omitting this parameter, you must provide either `file` or `content`.',  # noqa: E501
+            },
             'file_path': {
                 'name': 'file_path',
                 'type': 'string',
                 'required': False,
-                'description': 'Path to the file on the local filesystem that will be opened, read and uploaded to Slack. If omitting this parameter, you must submit either `file` or `content`.',  # noqa: E501
+                'description': 'Path to the file on the local filesystem that will be opened, read and uploaded to Slack. If omitting this parameter, you must provide either `file` or `content`.',  # noqa: E501
             }
         }
     }

--- a/bin/generate_openapi.py
+++ b/bin/generate_openapi.py
@@ -25,13 +25,13 @@ METHOD_OVERRIDES = {
                 'name': 'content',
                 'type': 'string',
                 'required': False,
-                'description': 'File contents via a POST variable. If omitting this parameter, you must provide either `file` or `content`.',  # noqa: E501
+                'description': 'File contents via a POST variable. If omitting this parameter, you must provide either `file` or `file_path`.',  # noqa: E501
             },
             'file': {
                 'name': 'file',
                 'type': 'string',
                 'required': False,
-                'description': 'File contents via `multipart/form-data`. If omitting this parameter, you must provide either `file` or `content`.',  # noqa: E501
+                'description': 'File contents via `multipart/form-data`. If omitting this parameter, you must provide either `file_path` or `content`.',  # noqa: E501
             },
             'file_path': {
                 'name': 'file_path',

--- a/bin/template.jinja
+++ b/bin/template.jinja
@@ -1,6 +1,6 @@
 description: "{{ description }}"
 enabled: true
-entry_point: run.py
+entry_point: {{ entry_point }}
 name: {{ method }}
 parameters:
   end_point:


### PR DESCRIPTION
With the previous implementation of `files.upload` you would have to read the file and pass the `content` as an input to this action to get it to work.

What i've done is add a new `file_path` paramter and expect it to be a path to a file. If specified, we'll read the data from the filesystem and upload it to Slack.

For backwards compatibility this is a new parameter instead of piggy backing on an existing one. If the users specified `file_path` and `file` we throw an error with a helpful message because the `file` parameter is used on the request when sending the data.