### PR TITLE
Fix check for error with empty strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 2.0.1
+
+* Remove default value from `slack.files.upload` `file_path` parameter
+
 # 2.0.0
 
 * Drop Python 2.7 support

--- a/actions/files.upload.yaml
+++ b/actions/files.upload.yaml
@@ -25,7 +25,6 @@ parameters:
     type: string
   file_path:
     required: false
-    default: ""
     description: "Path to the file on the local filesystem that will be opened, read and uploaded to Slack. If omitting this parameter, you must provide either `file` or `content`."
     type: string
   filename:

--- a/actions/files_upload.py
+++ b/actions/files_upload.py
@@ -6,8 +6,8 @@ class FilesUploadAction(SlackAction):
     def run(self, **kwargs):
         # https://requests.readthedocs.io/en/master/user/quickstart/#post-a-multipart-encoded-file
         files = None
-        if 'file_path' in kwargs and kwargs['file_path'] != '':
-            if 'file' in kwargs and kwargs['file'] != '':
+        if 'file_path' in kwargs and kwargs['file_path']:
+            if 'file' in kwargs and kwargs['file']:
                 raise RuntimeError('Passing in "file" and "file_path" at the same time is'
                                    ' not supported. If you would like to have this action'
                                    ' read the file from the filesystem and upload it for you'

--- a/actions/files_upload.py
+++ b/actions/files_upload.py
@@ -6,8 +6,8 @@ class FilesUploadAction(SlackAction):
     def run(self, **kwargs):
         # https://requests.readthedocs.io/en/master/user/quickstart/#post-a-multipart-encoded-file
         files = None
-        if 'file_path' in kwargs:
-            if 'file' in kwargs and kwargs['file']:
+        if 'file_path' in kwargs and kwargs['file_path'] != '':
+            if 'file' in kwargs and kwargs['file'] != '':
                 raise RuntimeError('Passing in "file" and "file_path" at the same time is'
                                    ' not supported. If you would like to have this action'
                                    ' read the file from the filesystem and upload it for you'

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 2.0.0
+version: 2.0.1
 python_versions:
   - "3"
 author : StackStorm, Inc.


### PR DESCRIPTION
When calling this from the UI or within an action/workflow it seems that
even if you don't supply values for file or file_path, the end result is
these are getting passed as empty strings not non-existant parameters
resulting in this logic failing. Testing for empty strings fixes this
issue.

TBH I'm not sure if maybe the empty string thing is something with my environment specifically, a change in stackstorm, or something I'm missing entirely but this fixed the issues I was having with only passing `content`