### PR TITLE
Betterize http_method param

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# 2.0.2
+
+* Make the `http_method` parameter to `files.upload` not required, and make it
+  an enum parameter since only POST and GET are supported anyway.
+
 # 2.0.1
 
 * Remove default value from `slack.files.upload` `file_path` parameter

--- a/actions/files.upload.yaml
+++ b/actions/files.upload.yaml
@@ -8,9 +8,17 @@ parameters:
     immutable: true
     type: string
   http_method:
-    default: POST
-    required: true
+    # See SlackAction.run() in run.py - no other HTTP methods are supported,
+    # so why force users to specify this when they don't have to? Specifying an
+    # enum at least gives them a dropdown of the allowed options, and not
+    # requiring this parameter and defaulting to the preferred HTTP method is
+    # faster and easier for users.
+    default: POST    # From https://api.slack.com/methods/files.upload:
+    required: false  # Preferred HTTP method: POST
     type: string
+    enum:
+      - POST
+      - GET
   channels:
     required: false
     description: "Comma-separated list of channel names or IDs where the file will be shared."

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 2.0.1
+version: 2.0.2
 python_versions:
   - "3"
 author : StackStorm, Inc.


### PR DESCRIPTION
The `FilesUploadAction.run()` method in `files_upload.py` runs some checks and then passes the parameters to `super().run()`:

```python
class FilesUploadAction(SlackAction):

    def run(self, **kwargs):
        # ...
        super(FilesUploadAction, self).run(files=files, **kwargs)
```

and the `SlackAction.run()` method in `run.py` doesn't allow an `http_method` other than `GET` or `POST`:

```python

        if http_method == 'POST':
            # ...
        elif http_method == 'GET':
            # ...
        else:
            failure_reason = ('Failed to perform action %s: Invalid HTTP method: %s' % (
                end_point, http_method))
            self.logger.exception(failure_reason)
            raise Exception(failure_reason)
```

so it makes no sense to allow our users to specify any other value in `http_method` for `files.upload`. This PR tweaks that parameter to an enum type.

Additionally, according to the [Slack API docs](https://api.slack.com/methods/files.upload):

> Preferred HTTP method: `POST`

Since it really doesn't make any RESTful sense to pass a file over a GET request, this method will almost always be called with `http_method: POST`, and it would then make sense to give it a default value of `POST` (which it had) but also not make it a required parameter. This PR subsequently specifies `required: false`.

Since all previous users will be specifying `POST` or `GET` (but almost entirely `POST`) anyway, this change is backwards compatible.