### PR TITLE
Add support for token auth on apps/bots created post February 21, 2021

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# 2.0.3
+
+* Add support for Slack apps created post Feb. 24, 2021 that no longer support
+  tokens being passed in the url
+
 # 2.0.2
 
 * Make the `http_method` parameter to `files.upload` not required, and make it

--- a/actions/run.py
+++ b/actions/run.py
@@ -26,6 +26,8 @@ class SlackAction(Action):
 
         headers = {}
         headers['Content-Type'] = 'application/x-www-form-urlencoded'
+        headers['Authorization'] = 'Bearer %s' % (params['token'])
+        del params['token']
 
         for key in list(params.keys()):
             if params[key] is None:

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 2.0.2
+version: 2.0.3
 python_versions:
   - "3"
 author : StackStorm, Inc.


### PR DESCRIPTION
Passing the auth token in the URL is no longer supported for Slack apps created post Feb 21, 2021 
https://api.slack.com/changelog/2020-11-no-more-tokens-in-querystrings-for-newly-created-apps

This PR moves the token from the URL to the Authorization header instead.