### PR TITLE
Change slack endpoints and fix json.loads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+# 2.0.4
+
+* Add support for `conversations.info` slack method  as `groups.info` and
+  `channels.info` were deprecated.
+* Fix a bug in `SlackSensor._api_call`. There is no need to `json.loads` the
+  result as slackclient 1.3.1 already parses the json.
+
 # 2.0.3
 
 * Add support for Slack apps created post Feb. 24, 2021 that no longer support

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 2.0.3
+version: 2.0.4
 python_versions:
   - "3"
 author : StackStorm, Inc.

--- a/sensors/slack_sensor.py
+++ b/sensors/slack_sensor.py
@@ -231,7 +231,7 @@ class SlackSensor(PollingSensor):
 
     def _get_channel_info(self, channel_id):
         if channel_id not in self._channel_info_cache:
-            result = self._api_call('channels.info', channel=channel_id)
+            result = self._api_call('conversations.info', channel=channel_id)
 
             if 'channel' not in result:
                 # Channel doesn't exist or other error
@@ -244,7 +244,7 @@ class SlackSensor(PollingSensor):
 
     def _get_group_info(self, group_id):
         if group_id not in self._group_info_cache:
-            result = self._api_call('groups.info', channel=group_id)
+            result = self._api_call('conversations.info', channel=group_id)
             self._logger.warn('GROUP DATA: %s' % result)
             if 'group' not in result:
                 # Group doesn't exist or other error
@@ -256,6 +256,4 @@ class SlackSensor(PollingSensor):
         return self._group_info_cache[group_id]
 
     def _api_call(self, method, **kwargs):
-        result = self._client.api_call(method, **kwargs)
-        result = json.loads(result)
-        return result
+        return self._client.api_call(method, **kwargs)

--- a/sensors/slack_sensor.py
+++ b/sensors/slack_sensor.py
@@ -1,4 +1,3 @@
-import json
 import re
 
 import eventlet


### PR DESCRIPTION
* Slack endpoints groups.info and channels.info were changed to conversations.info
* slackclient 1.3.1 does json.loads prior to returning api response