### PR TITLE
Upgrade lxml to 4.6.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 2.1.0
+
+* Upgrade lxml dependency from 3.8.0 to 4.6.5
+
 # 2.0.5
 
 * Add `blocks` from slack message to sensor `payload`

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 2.0.5
+version: 2.1.0
 python_versions:
   - "3"
 author : StackStorm, Inc.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.5.0,<3.0
 websocket-client==0.44.0
 beautifulsoup4==4.6.0
-lxml==3.8.0
+lxml==4.6.5
 jinja2>=2.10.1
 slackclient==1.3.1


### PR DESCRIPTION
Thanks for your reply @armab, here is the PR you asked me about.

This PR fixes #71 by upgrading the `lxml` dependency.
Installation of the pack on Ubuntu 20 was successful and I was able to run actions and send messages to Slack.

## Changelog

* Upgrade lxml dependency from 3.8.0 to 4.6.5
