### PR TITLE
added post_attachment action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 2.2.0
+
+* Added action `post_attachment`
+
 # 2.1.0
 
 * Upgrade lxml dependency from 3.8.0 to 4.6.5

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # 2.2.0
 
 * Added action `post_attachment`
+* Added missing `icon_url` to config schema
 
 # 2.1.0
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Example trigger payload:
 
 ## Actions
 
-The following two actions are provided by the Slack pack.
+The following actions are provided by the Slack pack.
 
 * ``post_message`` - Post a message to the specified channel using an incoming webhook.
 * ``post_attachment`` - Post an attachment to the specified channel using an incoming webhook.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Note: Actions ``post_message`` and ``post_attachment`` use the same ``post_messa
   messages will be posted. This setting can be overridden on per action basis.
   If not provided, default value which is selected when configuring a webhook
   is used.
+* ``post_message_action.icon_url`` - Default icon url of the user under which the
+  messages will be posted. This setting can be overridden on per action basis.
+  If not provided, default value which is selected when configuring a webhook
+  is used.
 * ``sensor.token`` - Authentication token used to authenticate against Real
   Time Messaging API.
 * ``sensor.strip_formatting`` - By default, Slack automatically parses URLs, images,

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Example trigger payload:
 The following two actions are provided by the Slack pack.
 
 * ``post_message`` - Post a message to the specified channel using an incoming webhook.
+* ``post_attachment`` - Post an attachment to the specified channel using an incoming webhook.
 * ``users.admin.invite`` - Send an invitation to join a Slack Org.
 * ``users_filter_by`` - List users in a Slack team matching certain creterias.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Pack which allows integration with [Slack](https://slack.com/) service.
 ## Configuration
 
 Copy the example configuration in [`slack.yaml.example`](./slack.yaml.example)
-to `/opt/stackstorm/configs/slack.yaml` and edit as required.
+to `/opt/stackstorm/configs/slack.yaml` and edit as required. 
+Note: Actions ``post_message`` and ``post_attachment`` use the same ``post_message_action`` configuration.
 
 * ``post_message_action.webhook_url`` - Webhook URL.
 * ``post_message_action.channel`` - Channel to send the message to (e.g.

--- a/actions/post_attachment.py
+++ b/actions/post_attachment.py
@@ -1,0 +1,63 @@
+import json
+
+from six.moves.urllib.parse import urlencode
+import requests
+
+from st2common.runners.base_action import Action
+
+__all__ = [
+    'PostMessageAction'
+]
+
+
+class PostMessageAction(Action):
+    def run(self, attachment, username=None, icon_emoji=None, icon_url=None, channel=None,
+            disable_formatting=False, webhook_url=None):
+        config = self.config.get('post_message_action', {})
+        username = username if username else config['username']
+        icon_emoji = icon_emoji if icon_emoji else config.get('icon_emoji', None)
+        icon_url = icon_url if icon_url else config.get('icon_url', None)
+        channel = channel if channel else config.get('channel', None)
+        webhook_url = webhook_url if webhook_url else config.get('webhook_url', None)
+
+        if not webhook_url:
+            raise ValueError('"webhook_url" needs to be either provided via '
+                             'action parameter or specified as part of '
+                             'post_message_action.webhook_url config option"')
+
+        headers = {}
+        headers['Content-Type'] = 'application/x-www-form-urlencoded'
+        body = {
+            'username': username,
+            'attachments': [attachment]
+        }
+
+        if icon_emoji:
+            body['icon_emoji'] = icon_emoji
+
+        if icon_url:
+            body['icon_url'] = icon_url
+
+        if channel:
+            body['channel'] = channel
+
+        if disable_formatting:
+            body['parse'] = 'none'
+
+        if webhook_url:
+            body['webhook_url'] = webhook_url
+
+        data = {'payload': json.dumps(body)}
+        data = urlencode(data)
+        response = requests.post(url=webhook_url,
+                                 headers=headers, data=data)
+
+        if response.status_code == requests.codes.ok:  # pylint: disable=no-member
+            self.logger.info('Message successfully posted')
+        else:
+            failure_reason = ('Failed to post message: %s (status code: %s)' %
+                              (response.text, response.status_code))
+            self.logger.exception(failure_reason)
+            raise Exception(failure_reason)
+
+        return True

--- a/actions/post_attachment.py
+++ b/actions/post_attachment.py
@@ -16,7 +16,6 @@ class PostMessageAction(Action):
         config = self.config.get('post_message_action', {})
         username = username if username else config['username']
         icon_emoji = icon_emoji if icon_emoji else config.get('icon_emoji', None)
-        icon_url = icon_url if icon_url else config.get('icon_url', None)
         channel = channel if channel else config.get('channel', None)
         webhook_url = webhook_url if webhook_url else config.get('webhook_url', None)
 

--- a/actions/post_attachment.py
+++ b/actions/post_attachment.py
@@ -10,12 +10,13 @@ __all__ = [
 ]
 
 
-class PostMessageAction(Action):
+class PostAttachmentAction(Action):
     def run(self, attachment, username=None, icon_emoji=None, icon_url=None, channel=None,
             disable_formatting=False, webhook_url=None):
         config = self.config.get('post_message_action', {})
         username = username if username else config['username']
         icon_emoji = icon_emoji if icon_emoji else config.get('icon_emoji', None)
+        icon_url = icon_url if icon_url else config.get('icon_url', None)
         channel = channel if channel else config.get('channel', None)
         webhook_url = webhook_url if webhook_url else config.get('webhook_url', None)
 

--- a/actions/post_attachment.yaml
+++ b/actions/post_attachment.yaml
@@ -1,0 +1,36 @@
+---
+  name: "post_attachment"
+  runner_type: "python-script"
+  description: "Post an attachment to the Slack channel."
+  enabled: true
+  entry_point: "post_attachment.py"
+  parameters:
+    attachment:
+      type: "object"
+      description: "Attachment to send (only one allowed)"
+      required: true
+    username:
+      type: "string"
+      description: "Bot username."
+      required: false
+    channel:
+      type: "string"
+      description: "Optional channel to post to. Note channel must contain leading #"
+      required: false
+    icon_emoji:
+      type: "string"
+      description: "Bot icon emoji"
+      required: false
+    icon_url:
+      type: "string"
+      description: "Bot icon URL"
+      required: false
+    disable_formatting:
+      type: "boolean"
+      description: "Disable formatting, don't parse the message and treat it as raw text"
+      required: false
+      default: false
+    webhook_url:
+      type: "string"
+      description: "Optional Webhook url"
+      required: false

--- a/actions/post_message.py
+++ b/actions/post_message.py
@@ -16,6 +16,7 @@ class PostMessageAction(Action):
         config = self.config.get('post_message_action', {})
         username = username if username else config['username']
         icon_emoji = icon_emoji if icon_emoji else config.get('icon_emoji', None)
+        icon_url = icon_url if icon_url else config.get('icon_url', None)
         channel = channel if channel else config.get('channel', None)
         webhook_url = webhook_url if webhook_url else config.get('webhook_url', None)
 

--- a/actions/post_message.py
+++ b/actions/post_message.py
@@ -16,7 +16,6 @@ class PostMessageAction(Action):
         config = self.config.get('post_message_action', {})
         username = username if username else config['username']
         icon_emoji = icon_emoji if icon_emoji else config.get('icon_emoji', None)
-        icon_url = icon_url if icon_url else config.get('icon_url', None)
         channel = channel if channel else config.get('channel', None)
         webhook_url = webhook_url if webhook_url else config.get('webhook_url', None)
 

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -24,6 +24,10 @@
         type: "string"
         description: "Default icon of user under which messages will be posted"
         required: false
+      icon_url:
+        type: "string"
+        description: "Default icon url of user under which messages will be posted"
+        required: false
   sensor:
     description: "Sensor specific settings."
     type: "object"

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 2.1.0
+version: 2.2.0
 python_versions:
   - "3"
 author : StackStorm, Inc.

--- a/slack.yaml.example
+++ b/slack.yaml.example
@@ -5,6 +5,7 @@ post_message_action:
   channel: "#mychannel"
   username: "my-bot"
   icon_emoji: ":panda_face:"
+  icon_url: "https://myiconurl.com"
 
 # Used for Slack sensor
 sensor:


### PR DESCRIPTION
Small feature addition allowing Stackstorm to post not only text to a Slack webhook but also an "attachment" as defined here https://api.slack.com/reference/messaging/attachments.

Attachment field is an object expecting the contents of the attachments list.

Example Attachment field object:
```json
{
	"fallback": "Post an Attachment",
	"title": "Post an Attachment",
	"color": "#f4ec00",
	"pretext": "Optional text that appears above the attachment block",
	"fields":[
		{
		"title": "Section1",
		"value": "Value1",
		"short": false
		},
		{
		"title": "Section2",
		"value": "Value2",
		"short": false
		}
	],
}
```

Example Curl:
```json
curl -X POST -H 'Content-type: application/json' \
--data '{ 
	"attachments": [
		{
			"fallback": "Post an Attachment",
			"title": "Post an Attachment",
			"color": "#f4ec00",
			"pretext": "Optional text that appears above the attachment block",
			"fields":[
				{
				"title": "Section1",
				"value": "Value1",
				"short": false
				},
				{
				"title": "Section2",
				"value": "Value2",
				"short": false
				}
			],
		}
	]
}' https://hooks.slack.com/services/my/endpoint/url
```