### PR TITLE
Fix misspelled class reference in post_attachment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 2.2.1
+
+* fix "__all__" reference for `post_attachment`
+
 # 2.2.0
 
 * Added action `post_attachment`

--- a/README.md
+++ b/README.md
@@ -248,4 +248,3 @@ accept raw data that will be uploaded.
 
 If you're a pack developer working on this pack and want to auto-generate / update
 the actions here, please see [bin/README.md](bin/README.md)
-

--- a/README.md
+++ b/README.md
@@ -248,3 +248,4 @@ accept raw data that will be uploaded.
 
 If you're a pack developer working on this pack and want to auto-generate / update
 the actions here, please see [bin/README.md](bin/README.md)
+

--- a/actions/post_attachment.py
+++ b/actions/post_attachment.py
@@ -6,7 +6,7 @@ import requests
 from st2common.runners.base_action import Action
 
 __all__ = [
-    'PostMessageAction'
+    'PostAttachmentAction'
 ]
 
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version: 2.2.0
+version: 2.2.1
 python_versions:
   - "3"
 author : StackStorm, Inc.


### PR DESCRIPTION
With CI running again, it was discovered a misspelled class reference for the post_attachment.py, fixed it.